### PR TITLE
Suisin/chore: add phone verification status on personal details page

### DIFF
--- a/packages/account/src/Sections/Profile/PersonalDetails/__tests__/verify-button.spec.tsx
+++ b/packages/account/src/Sections/Profile/PersonalDetails/__tests__/verify-button.spec.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { VerifyButton } from '../verify-button';
+import { StoreProvider, mockStore } from '@deriv/stores';
+
+describe('VerifyButton', () => {
+    const mock_store = mockStore({
+        client: {
+            account_settings: {
+                phone_number_verification: {
+                    verified: false,
+                },
+            },
+        },
+    });
+    it('should render Verify Button', () => {
+        render(
+            <StoreProvider store={mock_store}>
+                <VerifyButton />
+            </StoreProvider>
+        );
+        expect(screen.getByText('Verify')).toBeInTheDocument();
+    });
+
+    it('should render Verified text', () => {
+        mock_store.client.account_settings.phone_number_verification.verified = true;
+        render(
+            <StoreProvider store={mock_store}>
+                <VerifyButton />
+            </StoreProvider>
+        );
+        expect(screen.getByText('Verified')).toBeInTheDocument();
+        expect(screen.getByTestId('dt_phone_verification_popover')).toBeInTheDocument();
+    });
+
+    it('should render popover text when popover is clicked', () => {
+        mock_store.client.account_settings.phone_number_verification.verified = true;
+        render(
+            <StoreProvider store={mock_store}>
+                <VerifyButton />
+            </StoreProvider>
+        );
+        const popover = screen.getByTestId('dt_phone_verification_popover');
+        userEvent.click(popover);
+        expect(screen.getByText(/To change your verified phone number, contact us via/)).toBeInTheDocument();
+        expect(screen.getByText(/live chat/)).toBeInTheDocument();
+    });
+
+    it('should render live chat window when live chat is clicked', () => {
+        mock_store.client.account_settings.phone_number_verification.verified = true;
+        window.LC_API = {
+            open_chat_window: jest.fn(),
+            on_chat_ended: jest.fn(),
+        };
+
+        render(
+            <StoreProvider store={mock_store}>
+                <VerifyButton />
+            </StoreProvider>
+        );
+        const popover = screen.getByTestId('dt_phone_verification_popover');
+        userEvent.click(popover);
+        const livechat = screen.getByText(/live chat/);
+        userEvent.click(livechat);
+        expect(window.LC_API.open_chat_window).toHaveBeenCalled();
+    });
+});

--- a/packages/account/src/Sections/Profile/PersonalDetails/__tests__/verify-button.spec.tsx
+++ b/packages/account/src/Sections/Profile/PersonalDetails/__tests__/verify-button.spec.tsx
@@ -3,8 +3,16 @@ import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { VerifyButton } from '../verify-button';
 import { StoreProvider, mockStore } from '@deriv/stores';
+import { Router } from 'react-router';
+import { createBrowserHistory } from 'history';
+import { routes } from '@deriv/shared';
 
 describe('VerifyButton', () => {
+    const history = createBrowserHistory();
+    const renderWithRouter = (component: React.ReactElement) => {
+        return render(<Router history={history}>{component}</Router>);
+    };
+
     const mock_store = mockStore({
         client: {
             account_settings: {
@@ -14,8 +22,9 @@ describe('VerifyButton', () => {
             },
         },
     });
+
     it('should render Verify Button', () => {
-        render(
+        renderWithRouter(
             <StoreProvider store={mock_store}>
                 <VerifyButton />
             </StoreProvider>
@@ -23,9 +32,20 @@ describe('VerifyButton', () => {
         expect(screen.getByText('Verify')).toBeInTheDocument();
     });
 
+    it('should redirect user to phone-verification page when clicked on Verify Button', () => {
+        renderWithRouter(
+            <StoreProvider store={mock_store}>
+                <VerifyButton />
+            </StoreProvider>
+        );
+        const verifyButton = screen.getByText('Verify');
+        userEvent.click(verifyButton);
+        expect(history.location.pathname).toBe(routes.phone_verification);
+    });
+
     it('should render Verified text', () => {
         mock_store.client.account_settings.phone_number_verification.verified = true;
-        render(
+        renderWithRouter(
             <StoreProvider store={mock_store}>
                 <VerifyButton />
             </StoreProvider>
@@ -36,7 +56,7 @@ describe('VerifyButton', () => {
 
     it('should render popover text when popover is clicked', () => {
         mock_store.client.account_settings.phone_number_verification.verified = true;
-        render(
+        renderWithRouter(
             <StoreProvider store={mock_store}>
                 <VerifyButton />
             </StoreProvider>
@@ -54,7 +74,7 @@ describe('VerifyButton', () => {
             on_chat_ended: jest.fn(),
         };
 
-        render(
+        renderWithRouter(
             <StoreProvider store={mock_store}>
                 <VerifyButton />
             </StoreProvider>

--- a/packages/account/src/Sections/Profile/PersonalDetails/personal-details-form.tsx
+++ b/packages/account/src/Sections/Profile/PersonalDetails/personal-details-form.tsx
@@ -396,6 +396,10 @@ export const PersonalDetailsForm = observer(({ history }: { history: BrowserHist
                                             name='phone'
                                             id={'phone'}
                                             label={localize('Phone number*')}
+                                            className={
+                                                account_settings.phone_number_verification.verified &&
+                                                'account-form__fieldset--phone'
+                                            }
                                             //@ts-expect-error type of residence should not be null: needs to be updated in GetSettings type
                                             value={values.phone}
                                             onChange={handleChange}

--- a/packages/account/src/Sections/Profile/PersonalDetails/personal-details-form.tsx
+++ b/packages/account/src/Sections/Profile/PersonalDetails/personal-details-form.tsx
@@ -397,8 +397,9 @@ export const PersonalDetailsForm = observer(({ history }: { history: BrowserHist
                                             id={'phone'}
                                             label={localize('Phone number*')}
                                             className={
-                                                account_settings.phone_number_verification.verified &&
-                                                'account-form__fieldset--phone'
+                                                account_settings.phone_number_verification.verified
+                                                    ? 'account-form__fieldset--phone'
+                                                    : ''
                                             }
                                             //@ts-expect-error type of residence should not be null: needs to be updated in GetSettings type
                                             value={values.phone}

--- a/packages/account/src/Sections/Profile/PersonalDetails/personal-details-form.tsx
+++ b/packages/account/src/Sections/Profile/PersonalDetails/personal-details-form.tsx
@@ -398,7 +398,7 @@ export const PersonalDetailsForm = observer(({ history }: { history: BrowserHist
                                             id={'phone'}
                                             label={localize('Phone number*')}
                                             className={
-                                                account_settings.phone_number_verification.verified
+                                                account_settings?.phone_number_verification?.verified
                                                     ? 'account-form__fieldset--phone'
                                                     : ''
                                             }
@@ -410,7 +410,7 @@ export const PersonalDetailsForm = observer(({ history }: { history: BrowserHist
                                             error={errors.phone}
                                             disabled={
                                                 isFieldDisabled('phone') ||
-                                                account_settings.phone_number_verification.verified
+                                                account_settings?.phone_number_verification?.verified
                                             }
                                             data-testid='dt_phone'
                                         />

--- a/packages/account/src/Sections/Profile/PersonalDetails/personal-details-form.tsx
+++ b/packages/account/src/Sections/Profile/PersonalDetails/personal-details-form.tsx
@@ -407,7 +407,10 @@ export const PersonalDetailsForm = observer(({ history }: { history: BrowserHist
                                             onBlur={handleBlur}
                                             required
                                             error={errors.phone}
-                                            disabled={isFieldDisabled('phone')}
+                                            disabled={
+                                                isFieldDisabled('phone') ||
+                                                account_settings.phone_number_verification.verified
+                                            }
                                             data-testid='dt_phone'
                                         />
                                     </fieldset>

--- a/packages/account/src/Sections/Profile/PersonalDetails/personal-details-form.tsx
+++ b/packages/account/src/Sections/Profile/PersonalDetails/personal-details-form.tsx
@@ -31,6 +31,7 @@ import { getEmploymentStatusList } from 'Sections/Assessment/FinancialAssessment
 import InputGroup from './input-group';
 import { getPersonalDetailsInitialValues, getPersonalDetailsValidationSchema, makeSettingsRequest } from './validation';
 import FormSelectField from 'Components/forms/form-select-field';
+import { VerifyButton } from './verify-button';
 
 type TRestState = {
     show_form: boolean;
@@ -413,6 +414,7 @@ export const PersonalDetailsForm = observer(({ history }: { history: BrowserHist
                                             }
                                             data-testid='dt_phone'
                                         />
+                                        <VerifyButton />
                                     </fieldset>
                                 )}
                                 <React.Fragment>

--- a/packages/account/src/Sections/Profile/PersonalDetails/verify-button.tsx
+++ b/packages/account/src/Sections/Profile/PersonalDetails/verify-button.tsx
@@ -13,7 +13,7 @@ export const VerifyButton = observer(() => {
     const { is_mobile } = ui;
     const { account_settings } = client;
     const { phone_number_verification } = account_settings;
-    const { verified } = phone_number_verification;
+    const { verified: phone_number_verified } = phone_number_verification;
     const history = useHistory();
 
     const redirectToPhoneVerification = () => {
@@ -22,7 +22,7 @@ export const VerifyButton = observer(() => {
 
     return (
         <div className='account-form__phone-verification-btn'>
-            {verified ? (
+            {phone_number_verified ? (
                 <div className='account-form__phone-verification-btn--verified'>
                     <LegacyWonIcon iconSize='xs' />
                     <CaptionText bold color='#4bb4b3'>

--- a/packages/account/src/Sections/Profile/PersonalDetails/verify-button.tsx
+++ b/packages/account/src/Sections/Profile/PersonalDetails/verify-button.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { CaptionText } from '@deriv-com/quill-ui';
+import { observer, useStore } from '@deriv/stores';
+import { LegacyWonIcon } from '@deriv/quill-icons';
+import { useHistory } from 'react-router';
+import { routes } from '@deriv/shared';
+import { Popover, Text } from '@deriv/components';
+import { Localize } from '@deriv/translations';
+
+export const VerifyButton = observer(() => {
+    const [open_popover, set_open_popover] = React.useState(false);
+    const { client, ui } = useStore();
+    const { is_mobile } = ui;
+    const { account_settings } = client;
+    const { phone_number_verification } = account_settings;
+    const { verified } = phone_number_verification;
+    const history = useHistory();
+
+    const redirectToPhoneVerification = () => {
+        history.push(routes.phone_verification);
+    };
+
+    return (
+        <div className='account-form__phone-verification-btn'>
+            {verified ? (
+                <div className='account-form__phone-verification-btn--verified'>
+                    <LegacyWonIcon iconSize='xs' />
+                    <CaptionText bold color='#4bb4b3'>
+                        Verified
+                    </CaptionText>
+                    <Popover
+                        data_testid='dt_phone_verification_popover'
+                        alignment={is_mobile ? 'top' : 'right'}
+                        className='phone-verification__popover'
+                        icon='info'
+                        is_open={open_popover}
+                        disable_message_icon
+                        onClick={() => set_open_popover(prev => !prev)}
+                        message={
+                            <Text size='xxs'>
+                                <Localize
+                                    i18n_default_text='To change your verified phone number, contact us via <0>live chat</0>.'
+                                    components={[
+                                        <a
+                                            key={0}
+                                            className='link link--orange'
+                                            onClick={() => window.LC_API.open_chat_window()}
+                                        />,
+                                    ]}
+                                />
+                            </Text>
+                        }
+                        zIndex='9999'
+                    />
+                </div>
+            ) : (
+                <Text
+                    size='xxs'
+                    weight='bold'
+                    color='red'
+                    className='account-form__phone-verification-btn--not-verified'
+                    onClick={redirectToPhoneVerification}
+                >
+                    <Localize i18n_default_text='Verify' />
+                </Text>
+            )}
+        </div>
+    );
+});

--- a/packages/account/src/Styles/account.scss
+++ b/packages/account/src/Styles/account.scss
@@ -448,10 +448,10 @@ $MIN_HEIGHT_FLOATING: calc(
 
                 .phone-verification__popover {
                     position: absolute;
-                    right: -3rem;
+                    inset-inline-end: -3rem;
 
                     @include mobile {
-                        right: 0rem;
+                        inset-inline-end: 0rem;
                     }
                 }
             }

--- a/packages/account/src/Styles/account.scss
+++ b/packages/account/src/Styles/account.scss
@@ -436,7 +436,7 @@ $MIN_HEIGHT_FLOATING: calc(
                 display: flex;
                 padding-top: 0.6rem;
                 padding-inline-end: 1.2rem;
-                color: #4bb4b3;
+                color: var(--text-profit-success);
 
                 @include mobile {
                     padding-inline-end: 4rem;

--- a/packages/account/src/Styles/account.scss
+++ b/packages/account/src/Styles/account.scss
@@ -291,6 +291,12 @@ $MIN_HEIGHT_FLOATING: calc(
             position: relative;
             max-width: 400px;
 
+            &--phone {
+                @include mobile {
+                    padding-inline-end: 2.5rem;
+                }
+            }
+
             .cfd-personal-details-modal__form & {
                 margin: unset;
                 max-width: unset;
@@ -410,6 +416,42 @@ $MIN_HEIGHT_FLOATING: calc(
                 .date-of-birth-datepicker {
                     .datepicker-native__input {
                         height: 3.8rem;
+                    }
+                }
+            }
+        }
+        &__phone-verification-btn {
+            position: absolute;
+            inset-inline-end: 0;
+            top: 0.4rem;
+
+            &--not-verified {
+                display: flex;
+                padding-top: 0.6rem;
+                padding-inline-end: 1.2rem;
+                cursor: pointer;
+            }
+
+            &--verified {
+                display: flex;
+                padding-top: 0.6rem;
+                padding-inline-end: 1.2rem;
+                color: #4bb4b3;
+
+                @include mobile {
+                    padding-inline-end: 4rem;
+                }
+
+                > :first-child {
+                    padding-inline-end: 0.4rem;
+                }
+
+                .phone-verification__popover {
+                    position: absolute;
+                    right: -3rem;
+
+                    @include mobile {
+                        right: 0rem;
                     }
                 }
             }


### PR DESCRIPTION
## Changes:

Adding phone verification status on personal details page

### Screenshots:

<img width="757" alt="Screenshot 2024-04-29 at 2 07 18 PM" src="https://github.com/suisin-deriv/deriv-app/assets/103026762/85a8b24e-206e-4bcb-b5c6-49a7d5aa915c">


<img width="1116" alt="Screenshot 2024-04-29 at 2 08 33 PM" src="https://github.com/suisin-deriv/deriv-app/assets/103026762/31dc6502-c2da-4540-b860-fe7c4c902d3b">

